### PR TITLE
Validate and normalize poll interval configuration

### DIFF
--- a/custom_components/fansync_ble/__init__.py
+++ b/custom_components/fansync_ble/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
-from .const import DOMAIN, CONF_POLL_INTERVAL
+from .const import DOMAIN, CONF_POLL_INTERVAL, normalize_poll_interval
 
 if TYPE_CHECKING:
     # Only import HA types for type checking; avoid runtime dependency during tests
@@ -16,7 +16,9 @@ async def async_setup_entry(hass: "HomeAssistant", entry: "ConfigEntry"):
 
     address = entry.data["address"]
     poll = entry.options.get(CONF_POLL_INTERVAL) if entry.options else None
-    coord = FanSyncCoordinator(hass, address, poll_interval=poll)
+    coord = FanSyncCoordinator(
+        hass, address, poll_interval=normalize_poll_interval(poll)
+    )
     await coord.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coord
 

--- a/custom_components/fansync_ble/config_flow.py
+++ b/custom_components/fansync_ble/config_flow.py
@@ -13,6 +13,8 @@ from .const import (
     DEFAULT_DIMMABLE,
     DEFAULT_DIRECTION_SUPPORTED,
     DEFAULT_POLL_INTERVAL,
+    MIN_POLL_INTERVAL,
+    MAX_POLL_INTERVAL,
 )
 from .client import discover_candidates
 
@@ -74,7 +76,10 @@ class FanSyncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     ): bool,
                     vol.Required(
                         CONF_POLL_INTERVAL, default=DEFAULT_POLL_INTERVAL
-                    ): int,
+                    ): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(min=MIN_POLL_INTERVAL, max=MAX_POLL_INTERVAL),
+                    ),
                 }
             )
             if discovery_error:
@@ -95,7 +100,12 @@ class FanSyncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(
                     CONF_DIRECTION_SUPPORTED, default=DEFAULT_DIRECTION_SUPPORTED
                 ): bool,
-                vol.Required(CONF_POLL_INTERVAL, default=DEFAULT_POLL_INTERVAL): int,
+                vol.Required(
+                    CONF_POLL_INTERVAL, default=DEFAULT_POLL_INTERVAL
+                ): vol.All(
+                    vol.Coerce(int),
+                    vol.Range(min=MIN_POLL_INTERVAL, max=MAX_POLL_INTERVAL),
+                ),
             }
         )
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
@@ -135,7 +145,10 @@ class FanSyncOptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Required(
                     CONF_POLL_INTERVAL,
                     default=opts.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL),
-                ): int,
+                ): vol.All(
+                    vol.Coerce(int),
+                    vol.Range(min=MIN_POLL_INTERVAL, max=MAX_POLL_INTERVAL),
+                ),
             }
         )
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/fansync_ble/const.py
+++ b/custom_components/fansync_ble/const.py
@@ -21,3 +21,14 @@ DEFAULT_HAS_LIGHT = True
 DEFAULT_DIMMABLE = True
 DEFAULT_DIRECTION_SUPPORTED = False
 DEFAULT_POLL_INTERVAL = 15  # seconds
+MIN_POLL_INTERVAL = 5
+MAX_POLL_INTERVAL = 300
+
+
+def normalize_poll_interval(value) -> int:
+    """Normalize poll interval to a safe integer range."""
+    try:
+        ivalue = int(value)
+    except (TypeError, ValueError):
+        return DEFAULT_POLL_INTERVAL
+    return max(MIN_POLL_INTERVAL, min(MAX_POLL_INTERVAL, ivalue))

--- a/tests/test_const_poll_interval.py
+++ b/tests/test_const_poll_interval.py
@@ -1,0 +1,22 @@
+from custom_components.fansync_ble.const import (
+    DEFAULT_POLL_INTERVAL,
+    MAX_POLL_INTERVAL,
+    MIN_POLL_INTERVAL,
+    normalize_poll_interval,
+)
+
+
+def test_normalize_poll_interval_defaults_for_invalid_values():
+    assert normalize_poll_interval(None) == DEFAULT_POLL_INTERVAL
+    assert normalize_poll_interval("not-an-int") == DEFAULT_POLL_INTERVAL
+
+
+def test_normalize_poll_interval_clamps_to_bounds():
+    assert normalize_poll_interval(MIN_POLL_INTERVAL - 1) == MIN_POLL_INTERVAL
+    assert normalize_poll_interval(MAX_POLL_INTERVAL + 1) == MAX_POLL_INTERVAL
+
+
+def test_normalize_poll_interval_accepts_valid_values():
+    assert normalize_poll_interval(MIN_POLL_INTERVAL) == MIN_POLL_INTERVAL
+    assert normalize_poll_interval("42") == 42
+    assert normalize_poll_interval(MAX_POLL_INTERVAL) == MAX_POLL_INTERVAL


### PR DESCRIPTION
## Summary
- add poll interval min/max bounds in config and options flow schemas
- normalize poll interval at setup time for safety against legacy/bad values
- add unit tests for normalization behavior

## Validation
- pipenv run ruff check .
- pipenv run black --check .
- pipenv run pytest -q

Closes #1